### PR TITLE
Extending nominf action

### DIFF
--- a/src/chainActions/nominfAction.js
+++ b/src/chainActions/nominfAction.js
@@ -7,7 +7,9 @@ export default ({
   descriptor,
   picture,
   telegram,
-  twitter
+  twitter,
+  oig_prefix,
+  pubkey,
 }) => ({
   account: OIG_ACCOUNT,
   name: 'nominf',
@@ -20,6 +22,8 @@ export default ({
     telegram: telegram,
     twitter: twitter,
     wechat: '',
+    oig_prefix: oig_prefix,
+    pubkey: pubkey,
     remove: false
   }
 });

--- a/src/components/election/BallotNomination.vue
+++ b/src/components/election/BallotNomination.vue
@@ -23,6 +23,9 @@ const store = useStore();
 const session = useSession();
 
 const nominees = computed(() => store.state.ballot.nominees);
+const candidates = computed(() => store.state.ballot.candidates);
+
+const isActorNotACandidate = computed(() => candidates.value.filter((candidate) => session?.value?.actor?.toString() == candidate?.owner).length == 0);
 
 const isOpen = ref(false);
 const isConfirmationModalOpen = ref(false);
@@ -103,8 +106,13 @@ onMounted(() => {
                 <h3 class="truncate text-sm font-medium text-font">
                   {{ nominee.nominee }}
                 </h3>
+                <CandidateCardEdit
+                  v-if="session?.actor?.toString() == nominee?.nominee && nominee.accepted && isActorNotACandidate"
+                  :candidate="nominee"
+                  :acceptance="true"
+                />
                 <span
-                  v-if="nominee.accepted"
+                  v-else-if="nominee.accepted"
                   class="inline-flex flex-shrink-0 items-center rounded-full border border-gray-200 bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-70 outline-none"
                   >accepted</span
                 >
@@ -128,7 +136,7 @@ onMounted(() => {
           @click="openModal"
         >
           <div
-            class="hover:cursor-pointer flex w-full items-center justify-between space-x-6 px-6 py-5"
+            class="hover:cursor-pointer flex w-full h-full items-center justify-between space-x-6 px-6 py-5"
           >
             <div class="flex-1 truncate">
               <div class="flex items-center space-x-3">

--- a/src/components/election/CandidateCardEdit.vue
+++ b/src/components/election/CandidateCardEdit.vue
@@ -27,6 +27,7 @@ const formData = reactive({ ...props.candidate });
 
 const handleRegexValidation = (value) => /^@[a-zA-Z0-9_]{0,15}/.test(value);
 const oigPrefixRegexValidation = (value) => /^[a-z1-5.]{1,11}[a-z1-5]$|(^[a-z1-5.]{12}[a-j1-5]$)/.test(value);
+const pubkeyRegexValidation = (value) => /^PUB_K1_[1-9A-HJ-NP-Za-km-z]{50}$|^EOS[1-9A-HJ-NP-Za-km-z]{50}$/.test(value);
 
 const rules = {
   name: { required, minLength: minLength(3) },
@@ -35,7 +36,7 @@ const rules = {
   telegram: { handleRegexValidation },
   twitter: { handleRegexValidation },
   oig_prefix: { required, maxLength: maxLength(8), oigPrefixRegexValidation },
-  pubkey: { required }
+  pubkey: { pubkeyRegexValidation }
 };
 
 const $v = useVuelidate(rules, formData);
@@ -303,12 +304,8 @@ async function submit() {
                               'border-red-700': $v.pubkey.$errors.length
                             }"
                           />
-                          <p
-                            class="text-red-700"
-                            v-for="error in $v.pubkey.$errors"
-                            :key="error.$uid"
-                          >
-                            {{ error.$message }}
+                          <p class="text-red-700" v-if="$v.pubkey.$error">
+                            Not a valid Public Key
                           </p>
                         </dd>
                       </div>

--- a/src/components/election/CandidateDetails.vue
+++ b/src/components/election/CandidateDetails.vue
@@ -147,6 +147,7 @@ const closeModal = () => router.push('/election');
                     </dd>
                   </div>
                   <div
+                    v-if="session?.actor?.toString() == candidate?.owner"
                     class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
                   >
                     <dt class="text-sm font-medium leading-6 text-primary">
@@ -160,6 +161,7 @@ const closeModal = () => router.push('/election');
                     </dd>
                   </div>
                   <div
+                    v-if="session?.actor?.toString() == candidate?.owner"
                     class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
                   >
                     <dt class="text-sm font-medium leading-6 text-primary">

--- a/src/components/election/CandidateDetails.vue
+++ b/src/components/election/CandidateDetails.vue
@@ -150,6 +150,32 @@ const closeModal = () => router.push('/election');
                     class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
                   >
                     <dt class="text-sm font-medium leading-6 text-primary">
+                      OIG prefix (Only visible to you)
+                    </dt>
+                    <dd
+                      class="mt-1 text-sm leading-6 text-font sm:col-span-2 sm:mt-0"
+                    >
+                      <span v-if="candidate?.oig_prefix">{{ candidate?.oig_prefix }}</span>
+                      <span v-else>–</span>
+                    </dd>
+                  </div>
+                  <div
+                    class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
+                  >
+                    <dt class="text-sm font-medium leading-6 text-primary">
+                      Public Key (Only visible to you)
+                    </dt>
+                    <dd
+                      class="mt-1 text-sm leading-6 text-font sm:col-span-2 sm:mt-0"
+                    >
+                      <span v-if="candidate?.pubkey">{{ candidate?.pubkey }}</span>
+                      <span v-else>–</span>
+                    </dd>
+                  </div>
+                  <div
+                    class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0"
+                  >
+                    <dt class="text-sm font-medium leading-6 text-primary">
                       Description
                     </dt>
                     <dd

--- a/src/store/modules/ballot.js
+++ b/src/store/modules/ballot.js
@@ -124,6 +124,8 @@ const actions = {
         telegram: payload.telegram,
         twitter: payload.twitter,
         wechat: payload.wechat,
+        oig_prefix: payload.oig_prefix,
+        pubkey: payload.pubkey,
         remove: false
       })
     ]);
@@ -153,6 +155,8 @@ const actions = {
         telegram: payload.telegram,
         twitter: payload.twitter,
         wechat: payload.wechat,
+        oig_prefix: payload.oig_prefix,
+        pubkey: payload.pubkey,
         remove: payload.remove
       })
     ]);


### PR DESCRIPTION
**The following enhancements were added on this Pull Request:**

* Added the newly extended oig_prefix and pubkey fields to the nominf action and the Candidate Details modal and form
* Allowed only the candidate to view their newly extended fields information
* Made the pubkey field validation as required, and the oig_prefix field validation as required, max 8 characters and in accordance to eosio naming standard
* Small styling and flow fixes

Implements https://github.com/wax-office-of-inspector-general/oig.wax.io/issues/19

![image](https://github.com/wax-office-of-inspector-general/oig.wax.io/assets/26175688/9d91a1ac-f449-4021-8b65-d7068d7f4dd4)

![image](https://github.com/wax-office-of-inspector-general/oig.wax.io/assets/26175688/d7ec8ed5-4e86-4d06-83da-f07b72b7a93b)