### PR TITLE
Fixing the ballot and candidates fetch racing condition

### DIFF
--- a/src/components/election/BallotCandidates.vue
+++ b/src/components/election/BallotCandidates.vue
@@ -1,17 +1,11 @@
 <script setup>
 import CandidateCard from './CandidateCard.vue';
 import { useStore } from 'vuex';
-import { computed, onMounted } from 'vue';
+import { computed } from 'vue';
 
 const store = useStore();
 
 const candidates = computed(() => store.state.ballot.candidates);
-
-onMounted(() => {
-  if (!candidates.value.length) store.dispatch('ballot/fetchCandidates');
-
-  setTimeout(() => store.dispatch('ballot/fetchVotingBallots'), 3000);
-});
 </script>
 <template>
   <div

--- a/src/store/modules/ballot.js
+++ b/src/store/modules/ballot.js
@@ -48,7 +48,7 @@ const notifyNoSessionError = () => {
 
 // actions
 const actions = {
-  async fetchBallots({ commit }, forcedState) {
+  async fetchBallots({ commit, dispatch }, forcedState) {
     try {
       const { rows } = await useBallots();
 
@@ -59,6 +59,8 @@ const actions = {
     } catch (err) {
       console.log(err);
     }
+
+    dispatch('fetchCandidates');
   },
   async fetchVotingBallots({ commit, state }) {
     try {


### PR DESCRIPTION
**The following adjustment was made on this Pull Request:**

* Fetching Candidates now happens synchronously after fetching ballots, which were causing a racing condition before, allowing the both ballot ID and state to be available when checking for the voting ballots, if voting is open.

Fixes #38 